### PR TITLE
Fix broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
           <li><p><strong>Open and Transparent</strong>: Because Portier uses email addresses, there is never any lock-in.</p></li>
         </ul>
 
-        <p>Portier is inspired by <a href="https://github.com/portier/portier.github.io/blob/main/OtherProjects.md">many projects</a> and considers itself a spiritual successor to <a href="https://login.persona.org">Mozilla Persona</a>.</p>
+        <p>Portier is inspired by <a href="https://github.com/portier/portier.github.io/blob/main/OtherProjects.md">many projects</a> and considers itself a spiritual successor to <a href="https://en.wikipedia.org/wiki/Mozilla_Persona">Mozilla Persona</a>.</p>
 
         <h2>Roadmap</h2>
 


### PR DESCRIPTION
The Mozilla Persona website that is linked is no longer live, so linking to the Wikipedia explanation of what Persona was instead.