### PR TITLE
Update the link to portier-nginx repo

### DIFF
--- a/using.html
+++ b/using.html
@@ -36,7 +36,7 @@
         <p>On the client site, you will have to implement the portier broker protocol. Instead of doing that manually you should use one of the libraries:</p>
 
         <ul>
-          <li><a href="https://gitlab.com/jimdigriz/portier-nginx">nginx</a></li>
+          <li><a href="https://github.com/InkbridgeNetworks/portier-nginx">nginx</a></li>
           <li><a href="https://github.com/portier/portier-node">Node</a></li>
           <li><a href="https://github.com/portier/portier-python">Python</a></li>
           <li><a href="https://github.com/vr2262/asyncio-portier">Python-asyncio</a></li>


### PR DESCRIPTION
The old link to portier-nginx is invalid, thus I point it to a new repo which I assume is the right place.